### PR TITLE
PCP-6453: fix app deployments readiness status on EKS hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ARG BUILD_VERSION=dev
 ARG TELEMETRY_PRIVATE_KEY=""
 ARG HELM_VERSION="v3.19.2"
 
+RUN mkdir -p /usr/local/bin
+
 # Install kubectl for development
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-ARG KINE_VERSION="v0.13.14"
+ARG KINE_VERSION="v0.14.14"
 FROM rancher/kine:${KINE_VERSION} AS kine
 
 # Build program
-FROM golang:1.24 AS builder
+FROM us-docker.pkg.dev/palette-images/build-base-images/golang:1.25.8-alpine AS builder
 
 WORKDIR /vcluster-dev
 ARG TARGETOS
 ARG TARGETARCH
 ARG BUILD_VERSION=dev
 ARG TELEMETRY_PRIVATE_KEY=""
-ARG HELM_VERSION="v3.17.3"
+ARG HELM_VERSION="v3.19.2"
 
 # Install kubectl for development
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
@@ -57,7 +57,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
 ENTRYPOINT ["go", "run", "-mod", "vendor", "cmd/vcluster/main.go", "start"]
 
 # we use alpine for easier debugging
-FROM alpine:3.22
+FROM us-central1-docker.pkg.dev/palette-images-dev/hardened-images/alpine:3.23-dev
 
 # install runtime dependencies
 RUN apk add --no-cache ca-certificates zstd tzdata

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM us-docker.pkg.dev/palette-images/build-base-images/golang:1.25.8-alpine as builder
 
 WORKDIR /vcluster-dev
 ARG TARGETOS
@@ -33,7 +33,7 @@ ENV GOCACHE=/.cache
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -mod vendor -tags embed_chart -o /vcluster cmd/vclusterctl/main.go
 
 # we use alpine for easier debugging
-FROM alpine:3.22
+FROM us-central1-docker.pkg.dev/palette-images-dev/hardened-images/alpine:3.23-dev
 # Set home to "/" in order to for kubectl to automatically pick up vcluster kube config
 ENV KUBECONFIG=/root/.kube/config
 COPY --from=builder /vcluster /usr/local/bin/vcluster

--- a/Dockerfile.cli.release
+++ b/Dockerfile.cli.release
@@ -1,7 +1,7 @@
 # we use alpine for easier debugging
-FROM alpine:3.22
+FROM us-central1-docker.pkg.dev/palette-images-dev/hardened-images/alpine:3.23-dev
 
-ARG HELM_VERSION="v3.17.3"
+ARG HELM_VERSION="v3.19.2"
 ARG TARGETARCH
 
 # Set root path as working directory

--- a/Dockerfile.cli.release
+++ b/Dockerfile.cli.release
@@ -7,6 +7,8 @@ ARG TARGETARCH
 # Set root path as working directory
 WORKDIR /
 
+RUN mkdir -p /usr/local/bin
+
 # Add devspace
 RUN wget -O devspace "https://github.com/loft-sh/devspace/releases/latest/download/devspace-linux-${TARGETARCH}" \
 	&& chmod +x devspace \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,15 +1,15 @@
-ARG KINE_VERSION="v0.13.14"
+ARG KINE_VERSION="v0.14.14"
 FROM rancher/kine:${KINE_VERSION} AS kine
 
 # Build the manager binary
-FROM alpine:3.22 AS builder
+FROM us-central1-docker.pkg.dev/palette-images-dev/hardened-images/alpine:3.23-dev AS builder
 
 WORKDIR /vcluster-dev
 
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG HELM_VERSION="v3.17.3"
+ARG HELM_VERSION="v3.19.2"
 
 # Add curl
 RUN apk add --no-cache curl
@@ -18,7 +18,7 @@ RUN apk add --no-cache curl
 RUN curl -s https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz > helm3.tar.gz && tar -zxvf helm3.tar.gz linux-${TARGETARCH}/helm && chmod +x linux-${TARGETARCH}/helm && mv linux-${TARGETARCH}/helm /usr/local/bin/helm && rm helm3.tar.gz && rm -R linux-${TARGETARCH}
 
 # we use alpine for easier debugging
-FROM alpine:3.22
+FROM us-central1-docker.pkg.dev/palette-images-dev/hardened-images/alpine:3.23-dev
 
 # install runtime dependencies
 RUN apk add --no-cache ca-certificates zstd tzdata

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -11,8 +11,7 @@ ARG TARGETARCH
 
 ARG HELM_VERSION="v3.19.2"
 
-# Add curl
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl && mkdir -p /usr/local/bin
 
 # Install helm binary
 RUN curl -s https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz > helm3.tar.gz && tar -zxvf helm3.tar.gz linux-${TARGETARCH}/helm && chmod +x linux-${TARGETARCH}/helm && mv linux-${TARGETARCH}/helm /usr/local/bin/helm && rm helm3.tar.gz && rm -R linux-${TARGETARCH}

--- a/pkg/patcher/apply.go
+++ b/pkg/patcher/apply.go
@@ -8,6 +8,7 @@ import (
 	"github.com/loft-sh/vcluster/pkg/syncer/synccontext"
 	"github.com/loft-sh/vcluster/pkg/util/clienthelper"
 	"github.com/loft-sh/vcluster/pkg/util/patch"
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -18,6 +19,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
+
+// maxResourceVersionConflictAttempts is how many times we try Update / Status().Update before
+// giving up on 409 Conflict after re-fetching and re-applying the merge patch.
+const maxResourceVersionConflictAttempts = 5
 
 func CreateVirtualObject(ctx *synccontext.SyncContext, pObj, vObj client.Object, eventRecorder record.EventRecorder, hasStatus bool) (ctrl.Result, error) {
 	gvk, err := apiutil.GVKForObject(vObj, scheme.Scheme)
@@ -247,19 +252,53 @@ func applyObjectWithPatch(ctx *synccontext.SyncContext, objPatch patch.Patch, ob
 
 	// create / update
 	afterObj := obj.DeepCopyObject().(client.Object)
+	key := client.ObjectKeyFromObject(obj)
 	if isStatus {
-		err = kubeClient.Status().Update(ctx, obj)
-		if err != nil {
-			return fmt.Errorf("update object status: %w", err)
+		var statusErr error
+		for i := 0; i < maxResourceVersionConflictAttempts; i++ {
+			if isUpdate {
+				mergeLiveHostPodStatusBeforeHostStatusWrite(ctx, kubeClient, obj, direction)
+			}
+			statusErr = kubeClient.Status().Update(ctx, obj)
+			if statusErr == nil {
+				break
+			}
+			if !kerrors.IsConflict(statusErr) {
+				return fmt.Errorf("update object status: %w", statusErr)
+			}
+			if i == maxResourceVersionConflictAttempts-1 {
+				return fmt.Errorf("update object status: %w", statusErr)
+			}
+			if err := kubeClient.Get(ctx, key, obj); err != nil {
+				return fmt.Errorf("get object after status conflict: %w", err)
+			}
+			if err := objPatch.Apply(obj); err != nil {
+				return fmt.Errorf("apply patch after status conflict: %w", err)
+			}
 		}
 	} else {
 		if isUpdate {
-			err = kubeClient.Update(ctx, obj)
-			if err != nil {
-				return fmt.Errorf("update object: %w", err)
+			var updateErr error
+			for i := 0; i < maxResourceVersionConflictAttempts; i++ {
+				updateErr = kubeClient.Update(ctx, obj)
+				if updateErr == nil {
+					break
+				}
+				if !kerrors.IsConflict(updateErr) {
+					return fmt.Errorf("update object: %w", updateErr)
+				}
+				if i == maxResourceVersionConflictAttempts-1 {
+					return fmt.Errorf("update object: %w", updateErr)
+				}
+				if err := kubeClient.Get(ctx, key, obj); err != nil {
+					return fmt.Errorf("get object after conflict: %w", err)
+				}
+				if err := objPatch.Apply(obj); err != nil {
+					return fmt.Errorf("apply patch after conflict: %w", err)
+				}
 			}
 		} else {
-			err = kubeClient.Create(ctx, obj)
+			err := kubeClient.Create(ctx, obj)
 			if err != nil {
 				return fmt.Errorf("create object: %w", err)
 			}
@@ -284,6 +323,74 @@ func applyObjectWithPatch(ctx *synccontext.SyncContext, objPatch patch.Patch, ob
 		}
 	}
 	return nil
+}
+
+// mergeLiveHostPodStatusBeforeHostStatusWrite overlays kubelet- and API-owned Pod status from the
+// live host object before we write the status subresource. The syncer can otherwise apply a patch
+// built from a stale virtual view, producing impossible combinations (for example Ready=False
+// while containerStatuses report ready) or touching immutable qosClass. Custom readiness-gate
+// conditions from the desired object are preserved.
+func mergeLiveHostPodStatusBeforeHostStatusWrite(ctx *synccontext.SyncContext, kubeClient client.Client, obj client.Object, direction synccontext.SyncDirection) {
+	if direction != synccontext.SyncVirtualToHost {
+		return
+	}
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod.GetNamespace() == "" {
+		return
+	}
+	live := &corev1.Pod{}
+	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(pod), live); err != nil {
+		return
+	}
+	desired := pod
+	desired.Status.ContainerStatuses = live.Status.ContainerStatuses
+	desired.Status.InitContainerStatuses = live.Status.InitContainerStatuses
+	desired.Status.EphemeralContainerStatuses = live.Status.EphemeralContainerStatuses
+	desired.Status.QOSClass = live.Status.QOSClass
+	if live.Status.StartTime != nil {
+		desired.Status.StartTime = live.Status.StartTime
+	}
+	desired.Status.NominatedNodeName = live.Status.NominatedNodeName
+
+	var kubeletConds []corev1.PodCondition
+	seenKubelet := make(map[corev1.PodConditionType]struct{})
+	for _, c := range live.Status.Conditions {
+		if !isKubeletManagedPodConditionType(c.Type) {
+			continue
+		}
+		kubeletConds = append(kubeletConds, c)
+		seenKubelet[c.Type] = struct{}{}
+	}
+	for _, c := range desired.Status.Conditions {
+		if !isKubeletManagedPodConditionType(c.Type) {
+			continue
+		}
+		if _, ok := seenKubelet[c.Type]; ok {
+			continue
+		}
+		kubeletConds = append(kubeletConds, c)
+		seenKubelet[c.Type] = struct{}{}
+	}
+	var customConds []corev1.PodCondition
+	for _, c := range desired.Status.Conditions {
+		if isKubeletManagedPodConditionType(c.Type) {
+			continue
+		}
+		customConds = append(customConds, c)
+	}
+	desired.Status.Conditions = append(kubeletConds, customConds...)
+}
+
+func isKubeletManagedPodConditionType(t corev1.PodConditionType) bool {
+	switch t {
+	case corev1.PodScheduled, corev1.PodInitialized, corev1.PodReady, corev1.ContainersReady,
+		corev1.PodReadyToStartContainers, corev1.DisruptionTarget,
+		corev1.PodResizePending, corev1.PodResizeInProgress,
+		corev1.PodConditionType("AllContainersRestarting"):
+		return true
+	default:
+		return false
+	}
 }
 
 func logCreate(ctx context.Context, direction synccontext.SyncDirection, obj client.Object) {


### PR DESCRIPTION
**Issue**
When syncing virtual → host Pod status, the merge patch could be built from a stale virtual view while the host kubelet had already advanced container readiness and related status. That could produce internally inconsistent host Pod status (for example Ready / ContainersReady disagreeing with containerStatuses) and could also surface as object has been modified / 409 conflicts on concurrent updates.

**Fix**
In pkg/patcher/apply.go, before each host Status().Update for Pods on SyncVirtualToHost, re-read the live host Pod and refresh kubelet/API-owned status fields (notably container/init/ephemeral container statuses, qosClass, startTime, nominatedNodeName, and standard pod conditions) from the live object, while preserving custom conditions (e.g. readiness gates) from the patched object. Additionally, Update / Status().Update now retry on 409 by re-fetching the latest object and re-applying the same merge patch (bounded attempts).
